### PR TITLE
Fix for https://gitlab.com/gitlab-org/gitlab/-/issues/290311

### DIFF
--- a/gitlab-release
+++ b/gitlab-release
@@ -59,10 +59,17 @@ class GitlabRelease:
         return res.json()['markdown']
 
     def set_release(self, message, update=False):
-        url = '/'.join((self.api_project_url, 'repository/tags', self.get_tag(), 'release'))
+        url = f'{self.api_project_url}/releases'
         headers = {'Content-Type': 'application/json'}
         body = {'description': message}
-        method = 'put' if update else 'post'
+
+        if update:
+            method = 'put'
+            url += '/' + self.get_tag()
+        else:
+            method = 'post'
+            body['tag_name'] = self.get_tag()
+
         res = self.request(method, url, headers=headers, json=body)
         return res.json()
 


### PR DESCRIPTION
Lately this script stopped working. The request that creates the release returns 400 with this text:
```json
{
    "message":"Release notes modification via tags API is deprecated, see https://gitlab.com/gitlab-org/gitlab/-/issues/290311"
}
```

There was some change in the GitLab API that deprecated the creation/updation of releases by using the tag endpoint. The old method eventually stopped working.

You can read more about that here:
https://gitlab.com/gitlab-org/gitlab/-/issues/290311

This PR provides a fix that makes the script work with the new API that can be found here:
https://docs.gitlab.com/ee/api/releases/#create-a-release
https://docs.gitlab.com/ee/api/releases/#update-a-release

In the meantime, if anyone needs to get it working quickly you can use this container:
https://hub.docker.com/repository/docker/hex08/gitlab-release